### PR TITLE
Adds implementation for OAuth providers

### DIFF
--- a/app/authenticators/firebase.js
+++ b/app/authenticators/firebase.js
@@ -68,9 +68,9 @@ export default Base.extend({
             });
           };
           if(options.redirect){
-            _this.get('firebase').authWithOAuthPopup(options.provider, callback);
+            _this.get('firebase').authWithOAuthRedirect(options.provider, callback);
           } else {
-            _this.get('firebase').authWithOAuthRedirect(options.provider, callback)
+            _this.get('firebase').authWithOAuthPopup(options.provider, callback)
           }
         });
       }

--- a/app/authenticators/firebase.js
+++ b/app/authenticators/firebase.js
@@ -40,25 +40,40 @@ export default Base.extend({
 
     },
     authenticate: function(options) {
-
-        var _this = this;
-
+      var _this = this;
+      if(options.provider === "password" || !options.provider){
         return new Promise(function(resolve, reject) {
-
-            _this.get('firebase').authWithPassword({
-                'email': options.email,
-                'password': options.password
-            }, function(error, authData) {
-                Ember.run(function() {
-                    if (error) {
-                        reject(error);
-                    } else {
-                        resolve(authData);
-                    }
-                });
-
+          _this.get('firebase').authWithPassword({
+              'email': options.email,
+              'password': options.password
+          }, function(error, authData) {
+            Ember.run(function() {
+              if (error) {
+                reject(error);
+              } else {
+                resolve(authData);
+              }
             });
+          });
         });
+      } else {
+        return new Promise(function(resolve, reject) {
+          var callback = function(error, authData) {
+            Ember.run(function() {
+              if (error) {
+                reject(error);
+              } else {
+                resolve(authData);
+              }
+            });
+          };
+          if(options.redirect){
+            _this.get('firebase').authWithOAuthPopup(options.provider, callback);
+          } else {
+            _this.get('firebase').authWithOAuthRedirect(options.provider, callback)
+          }
+        });
+      }
     },
     invalidate: function(data) {
 


### PR DESCRIPTION
This commit is backwards compatible because if a "provider" property is not available, it assumes the password login. 
If there is an "provider" property on the options hash (that is not password), then it utilizes Firebase's OAuth login.
An additional property of "redirect" is available as a boolean to allow users to pick between redirect and popup OAuth login.
Sorry, I might have changed the formatting.
